### PR TITLE
refactor: implement caching and clearing of search queries in Explore…

### DIFF
--- a/app/src/main/java/com/moscow/cineverse/MainActivity.kt
+++ b/app/src/main/java/com/moscow/cineverse/MainActivity.kt
@@ -4,12 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.navigation.compose.rememberNavController
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.ktx.Firebase
 import com.moscow.cineverse.designSystem.theme.CineVerseTheme
 import com.moscow.cineverse.navigation.CineVerseNavGraph
+
 
 class MainActivity : ComponentActivity() {
 
@@ -21,7 +21,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             CineVerseTheme {
-                CineVerseNavGraph(rememberNavController())
+                CineVerseNavGraph()
             }
         }
     }

--- a/data/src/main/java/com/local/SearchLocalDateSourceImpl.kt
+++ b/data/src/main/java/com/local/SearchLocalDateSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.local
 
+import android.util.Log
 import com.local.dao.search.ActorDao
 import com.local.dao.search.MovieDao
 import com.local.dao.search.SearchHistoryDao
@@ -29,8 +30,13 @@ class SearchLocalDateSourceImpl(
         searchHistoryDao.deleteSearchHistory(SearchHistoryEntity(searchTerm))
     }
 
+    override suspend fun deleteAllSearchHistory() {
+        searchHistoryDao.deleteAllSearchHistory()
+    }
+
     override suspend fun insertMovie(moviesEntity: List<MovieEntity>, searchTerm: String) {
         val updatedMovieEntity = moviesEntity.map { movie -> movie.copy(searchTerm = searchTerm) }
+        Log.d("SearchLocalDateSourceImpl", "insertMovie: $updatedMovieEntity")
         movieDao.insertMovies(updatedMovieEntity)
     }
 
@@ -40,6 +46,7 @@ class SearchLocalDateSourceImpl(
 
     override suspend fun insertActors(actors: List<ActorEntity>, searchTerm: String) {
         val updatedActors = actors.map { it.copy(searchTerm = searchTerm) }
+        Log.d("SearchLocalDateSourceImpl", "insertActors: $updatedActors")
         actorDao.insertActors(updatedActors)
     }
 
@@ -49,6 +56,7 @@ class SearchLocalDateSourceImpl(
 
     override suspend fun insertSeries(series: List<SeriesEntity>, searchTerm: String) {
         val updatedSeries = series.map { it.copy(searchTerm = searchTerm) }
+        Log.d("SearchLocalDateSourceImpl", "insertSeries: $updatedSeries")
         seriesDao.insertSeries(updatedSeries)
     }
 

--- a/data/src/main/java/com/local/dao/search/SearchHistoryDao.kt
+++ b/data/src/main/java/com/local/dao/search/SearchHistoryDao.kt
@@ -19,4 +19,6 @@ interface SearchHistoryDao {
 
     @Delete
     suspend fun deleteSearchHistory(searchHistory: SearchHistoryEntity)
+    @Query("DELETE FROM search_history_table")
+    suspend fun deleteAllSearchHistory()
 }

--- a/data/src/main/java/com/repository/explore/search/SearchLocalDateSource.kt
+++ b/data/src/main/java/com/repository/explore/search/SearchLocalDateSource.kt
@@ -11,6 +11,7 @@ interface SearchLocalDateSource {
     suspend fun insertSearchHistory(searchTerm: String)
 
     suspend fun deleteSearchHistory(searchTerm: String)
+    suspend fun deleteAllSearchHistory()
 
     suspend fun insertMovie(moviesEntity: List<MovieEntity>, searchTerm: String)
 

--- a/data/src/main/java/com/repository/explore/search/SearchRepositoryImpl.kt
+++ b/data/src/main/java/com/repository/explore/search/SearchRepositoryImpl.kt
@@ -1,10 +1,8 @@
 package com.repository.explore.search
 
-import androidx.room.Transaction
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
-import com.android.domain.exception.CineVerseException
 import com.android.domain.model.Actor
 import com.android.domain.model.Movie
 import com.android.domain.model.MultiSearch
@@ -36,41 +34,17 @@ class SearchRepositoryImpl(
         return searchLocalDateSource.getMoviesBySearchTerm(searchTerm).toDomain()
     }
 
-    @Transaction
     override suspend fun insertMovie(movies: List<Movie>, searchTerm: String) {
-        searchLocalDateSource.insertSearchHistory(searchTerm)
         searchLocalDateSource.insertMovie(movies.toEntity(searchTerm), searchTerm)
-        val deleteWork = OneTimeWorkRequestBuilder<DeleteQueryWorker>()
-            .setInitialDelay(1, TimeUnit.HOURS)
-            .setInputData(workDataOf(QUERY to searchTerm))
-            .addTag(DELETE_SEARCH_QUERY_HISTORY)
-            .build()
 
-        workManager.enqueue(deleteWork)
     }
 
     override suspend fun insertActors(actors: List<Actor>, searchTerm: String) {
-        searchLocalDateSource.insertSearchHistory(searchTerm)
         searchLocalDateSource.insertActors(actors.toEntity(searchTerm), searchTerm)
-        val deleteWork = OneTimeWorkRequestBuilder<DeleteQueryWorker>()
-            .setInitialDelay(1, TimeUnit.HOURS)
-            .setInputData(workDataOf(QUERY to searchTerm))
-            .addTag(DELETE_SEARCH_QUERY_HISTORY)
-            .build()
-
-        workManager.enqueue(deleteWork)
     }
 
     override suspend fun insertSeries(series: List<Series>, searchTerm: String) {
-        searchLocalDateSource.insertSearchHistory(searchTerm)
         searchLocalDateSource.insertSeries(series.toEntity(searchTerm), searchTerm)
-        val deleteWork = OneTimeWorkRequestBuilder<DeleteQueryWorker>()
-            .setInitialDelay(1, TimeUnit.HOURS)
-            .setInputData(workDataOf(QUERY to searchTerm))
-            .addTag(DELETE_SEARCH_QUERY_HISTORY)
-            .build()
-
-        workManager.enqueue(deleteWork)
     }
 
     override suspend fun getLocalSuggestions(): Flow<List<String>> {
@@ -88,14 +62,11 @@ class SearchRepositoryImpl(
 
     override suspend fun searchMulti(query: String): Flow<List<MultiSearch>> =
         flow {
-            val result = tryToExecute {
-                searchRemoteDataSource.searchMulti(query)
-            }
-            if (result.isNotEmpty()) {
-                emit(result.map { it.toDomain() })
-            } else {
-                throw CineVerseException.NotFoundCineVerseException
-            }
+            emit(
+                tryToExecute {
+                    searchRemoteDataSource.searchMulti(query)
+                }.map { it.toDomain() }
+            )
         }.flowOn(ioDispatcher)
 
     override suspend fun searchMovie(query: String, isHistory: Boolean): Flow<List<Movie>> =
@@ -107,11 +78,9 @@ class SearchRepositoryImpl(
             val result = tryToExecute {
                 searchRemoteDataSource.searchMovie(query)
             }
+            emit(result.map { it.toDomain() })
             if (result.isNotEmpty()) {
-                emit(result.map { it.toDomain() })
                 insertMovie(result.map { movie -> movie.toDomain() }, query)
-            } else {
-                throw CineVerseException.NotFoundCineVerseException
             }
         }.flowOn(ioDispatcher)
 
@@ -124,11 +93,9 @@ class SearchRepositoryImpl(
             val result = tryToExecute {
                 searchRemoteDataSource.searchSeries(query)
             }
+            emit(result.map { it.toDomain() })
             if (result.isNotEmpty()) {
-                emit(result.map { it.toDomain() })
                 insertSeries(result.map { series -> series.toDomain() }, query)
-            } else {
-                throw CineVerseException.NotFoundCineVerseException
             }
         }.flowOn(ioDispatcher)
 
@@ -141,11 +108,25 @@ class SearchRepositoryImpl(
             val result = tryToExecute {
                 searchRemoteDataSource.searchPearson(query)
             }
+            emit(result.map { it.toDomain() })
             if (result.isNotEmpty()) {
-                emit(result.map { it.toDomain() })
                 insertActors(result.map { actor -> actor.toDomain() }, query)
-            } else {
-                throw CineVerseException.NotFoundCineVerseException
             }
         }.flowOn(ioDispatcher)
+
+    override suspend fun cacheSearchQuery(query: String) {
+        tryToExecute {
+            searchLocalDateSource.insertSearchHistory(query)
+            val deleteWork = OneTimeWorkRequestBuilder<DeleteQueryWorker>()
+                .setInitialDelay(1, TimeUnit.HOURS)
+                .setInputData(workDataOf(QUERY to query))
+                .addTag(DELETE_SEARCH_QUERY_HISTORY)
+                .build()
+            workManager.enqueue(deleteWork)
+        }
+    }
+
+    override suspend fun clearSearchHistory() = tryToExecute {
+        searchLocalDateSource.deleteAllSearchHistory()
+    }
 }

--- a/data/src/main/java/com/utils/CineVerseException.kt
+++ b/data/src/main/java/com/utils/CineVerseException.kt
@@ -1,5 +1,7 @@
 package com.utils
 
+import com.android.domain.utils.ErrorMessages
+
 sealed class CineVerseExceptions(message: String? = null) : Exception(message) {
     class NotFoundCineVerseException : CineVerseExceptions(ErrorMessages.RESOURCE_NOT_FOUND) {
     }

--- a/design_system/src/main/java/com/moscow/cineverse/designSystem/component/search/SearchBar.kt
+++ b/design_system/src/main/java/com/moscow/cineverse/designSystem/component/search/SearchBar.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -144,20 +143,25 @@ fun SearchBar(
                         tint = Theme.colors.shade.tertiary,
                         modifier = Modifier
                             .size(20.dp)
-                            .clickable(onClick = {
-                                focusManager.clearFocus(force = true)
-                                focusRequester.freeFocus()
-                                isFocused = false
-                                blockRefocus = true
-                                onCancelButtonClicked()
-                            })
+                            .noRibbleClick{
+                                onValueChange("")
+                            }
                     )
                 } else {
                     trailingIcon()
                 }
             },
             keyboardOptions = keyboardOptions,
-            keyboardActions = keyboardActions,
+            keyboardActions = KeyboardActions (
+                onSearch = {
+                    keyboardActions.onSearch?.let { it() }
+                    isFocused = false
+                },
+                onDone = {
+                    keyboardActions.onDone?.let { it() }
+                    isFocused = false
+                }
+            ),
             shape = RoundedCornerShape(Theme.radius.large),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedTextColor = Theme.colors.shade.primary,

--- a/design_system/src/main/java/com/moscow/cineverse/designSystem/component/tabs/ExploreTabs.kt
+++ b/design_system/src/main/java/com/moscow/cineverse/designSystem/component/tabs/ExploreTabs.kt
@@ -49,13 +49,14 @@ fun ExploreTabs(
             TabRowDefaults.SecondaryIndicator(
                 Modifier
                     .tabIndicatorOffset(tabPositions[tabsToShow.indexOf(selectedTab)])
+                    .padding(horizontal = 16.dp)
                     .clip(
                         RoundedCornerShape(
                             topStart = Theme.radius.full,
                             topEnd = Theme.radius.full
                         )
                     )
-                    .padding(horizontal = 16.dp),
+                ,
                 color = selectedContentColor,
             )
         },

--- a/domain/src/main/java/com/android/domain/exception/Exception.kt
+++ b/domain/src/main/java/com/android/domain/exception/Exception.kt
@@ -1,9 +1,40 @@
 package com.android.domain.exception
 
-sealed class CineVerseException : Exception() {
-    object NotFoundCineVerseException : CineVerseException()
-    object ActorDetailsNotFoundException  : CineVerseException()
-    object GalleryNotFoundException  : CineVerseException()
-    object BestOfMoviesNotFoundException  : CineVerseException()
-    object MappingToDomainException: CineVerseException()
+import com.android.domain.utils.ErrorMessages
+
+sealed class CineVerseException(override val message: String? = null) : Exception(message) {
+    class NotFoundCineVerseException : CineVerseException(ErrorMessages.RESOURCE_NOT_FOUND) {
+    }
+
+    class NoSuggestionFoundException(message: String = ErrorMessages.NO_SUGGESTIONS_FOUND) :
+        CineVerseException(message)
+
+   data class IOException(override val message: String = ErrorMessages.NETWORK_ERROR) : CineVerseException()
+
+    class BadRequestException(message: String = ErrorMessages.BAD_REQUEST) :
+        CineVerseException(message)
+
+    class UnauthorizedException(message: String = ErrorMessages.UNAUTHORIZED) :
+        CineVerseException(message)
+
+    class NotFoundException(message: String = ErrorMessages.NOT_FOUND) :
+        CineVerseException(message)
+
+    class TooManyRequestsException(message: String = ErrorMessages.TOO_MANY_REQUESTS) :
+        CineVerseException(message)
+
+    class HttpException(val code: Int, message: String = ErrorMessages.HTTP_ERROR.format(code)) :
+        CineVerseException(message)
+
+    class TimeoutException(message: String = ErrorMessages.TIMEOUT) : CineVerseException(message)
+
+    class UnknownException(
+        message: String = ErrorMessages.UNKNOWN_ERROR,
+        cause: Throwable? = null,
+    ) : CineVerseException(message) {
+        init {
+            cause?.let { initCause(it) }
+        }
+    }
+    data  object MappingToDomainException: CineVerseException()
 }

--- a/domain/src/main/java/com/android/domain/repository/SearchRepository.kt
+++ b/domain/src/main/java/com/android/domain/repository/SearchRepository.kt
@@ -19,4 +19,6 @@ interface SearchRepository {
     suspend fun searchMovie(query: String,isHistory: Boolean = false): Flow<List<Movie>>
     suspend fun searchSeries(query: String,isHistory: Boolean = false): Flow<List<Series>>
     suspend fun searchActor(query: String,isHistory: Boolean = false): Flow<List<Actor>>
+    suspend fun cacheSearchQuery(query: String)
+    suspend fun clearSearchHistory()
 }

--- a/domain/src/main/java/com/android/domain/usecase/CacheSearchQueryUseCase.kt
+++ b/domain/src/main/java/com/android/domain/usecase/CacheSearchQueryUseCase.kt
@@ -1,0 +1,12 @@
+package com.android.domain.usecase
+
+import com.android.domain.repository.SearchRepository
+
+class CacheSearchQueryUseCase(
+    private val searchRepository: SearchRepository
+) {
+    suspend fun cacheSearchQuery(
+        query: String
+    ) = searchRepository.cacheSearchQuery(query)
+
+}

--- a/domain/src/main/java/com/android/domain/usecase/ClearSearchHistoryUseCase.kt
+++ b/domain/src/main/java/com/android/domain/usecase/ClearSearchHistoryUseCase.kt
@@ -1,0 +1,9 @@
+package com.android.domain.usecase
+
+import com.android.domain.repository.SearchRepository
+
+class ClearSearchHistoryUseCase(
+    private val searchRepository: SearchRepository
+) {
+    suspend fun clearSearchHistory() = searchRepository.clearSearchHistory()
+}

--- a/domain/src/main/java/com/android/domain/utils/ErrorMessages.kt
+++ b/domain/src/main/java/com/android/domain/utils/ErrorMessages.kt
@@ -1,4 +1,4 @@
-package com.utils
+package com.android.domain.utils
 
 object ErrorMessages {
     const val RESOURCE_NOT_FOUND = "Resource not found"

--- a/presentation/src/main/java/com/moscow/cineverse/base/BaseViewModel.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/base/BaseViewModel.kt
@@ -47,6 +47,14 @@ abstract class BaseViewModel<T, E>(
         }
     }
 
+    protected fun launchAndForget(
+        action: suspend () -> Unit,
+        onError: (Throwable) -> Unit,
+    ) = viewModelScope.launch {
+        runCatching { action() }
+            .onFailure(onError)
+    }
+
     protected fun <R> launchWithFlow(
         flowAction: suspend () -> Flow<R>,
         onSuccess: (R) -> Unit,

--- a/presentation/src/main/java/com/moscow/cineverse/di/PresentationModule.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/di/PresentationModule.kt
@@ -1,5 +1,7 @@
 package com.moscow.cineverse.di
 
+import com.android.domain.usecase.CacheSearchQueryUseCase
+import com.android.domain.usecase.ClearSearchHistoryUseCase
 import com.android.domain.usecase.GenreUseCase
 import com.android.domain.usecase.GetLocalSuggestions
 import com.android.domain.usecase.GetMovieByGenreIdUseCase
@@ -14,6 +16,7 @@ import com.android.domain.usecase.SuggestionUseCase
 import com.android.domain.usecase.actordetails.GetActorBestOfMovies
 import com.android.domain.usecase.actordetails.GetActorDetails
 import com.android.domain.usecase.actordetails.GetActorGallery
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val useCases = module {
@@ -31,6 +34,8 @@ val useCases = module {
     single { GetMovieDetailUseCase(get()) }
     single { GetSeriesDetailUseCase(get()) }
     single { GetReviewsPageUseCase(get()) }
+    singleOf(::CacheSearchQueryUseCase)
+    singleOf(::ClearSearchHistoryUseCase)
 }
 
 val presentationModule = viewModels + useCases

--- a/presentation/src/main/java/com/moscow/cineverse/navigation/CineVerseNavGraph.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/navigation/CineVerseNavGraph.kt
@@ -1,23 +1,35 @@
 package com.moscow.cineverse.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
 import com.moscow.cineverse.navigation.routes.CastBestOfMovieRoute
 import com.moscow.cineverse.navigation.routes.CastDetailsRoute
 import com.moscow.cineverse.navigation.routes.CastGalleryRoute
 import com.moscow.cineverse.navigation.routes.ExploreRoute
 import com.moscow.cineverse.navigation.routes.MovieDetailsRoute
 import com.moscow.cineverse.navigation.routes.SeriesDetailsRoute
+import com.moscow.cineverse.navigation.routes.exploreRoute
+
+val LocalNavController =
+    staticCompositionLocalOf<NavHostController> { error("No NavController provided") }
 
 @Composable
-fun CineVerseNavGraph(navController: NavHostController) {
-    NavHost(navController = navController, startDestination = ExploreRoute) {
-        ExploreRoute(navController)
-        CastDetailsRoute(navController)
-        CastGalleryRoute(navController)
-        CastBestOfMovieRoute(navController)
-        MovieDetailsRoute(navController)
-        SeriesDetailsRoute(navController)
+fun CineVerseNavGraph() {
+    val navController = rememberNavController()
+    CompositionLocalProvider(
+        LocalNavController provides navController
+    ) {
+        NavHost(navController = navController, startDestination = ExploreRoute) {
+            exploreRoute()
+            CastDetailsRoute(navController)
+            CastGalleryRoute(navController)
+            CastBestOfMovieRoute(navController)
+            MovieDetailsRoute(navController)
+            SeriesDetailsRoute(navController)
+        }
     }
 }

--- a/presentation/src/main/java/com/moscow/cineverse/navigation/routes/ExploreRoute.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/navigation/routes/ExploreRoute.kt
@@ -1,8 +1,6 @@
 package com.moscow.cineverse.navigation.routes
 
-import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.moscow.cineverse.screen.explore.ExploreScreen
 import kotlinx.serialization.Serializable
@@ -10,8 +8,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 object ExploreRoute
 
-fun NavGraphBuilder.ExploreRoute(navController: NavHostController) {
+fun NavGraphBuilder.exploreRoute() {
     composable<ExploreRoute>{
-        ExploreScreen(navController = navController)
+        ExploreScreen()
     }
 }

--- a/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreInteractionListener.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreInteractionListener.kt
@@ -18,8 +18,8 @@ interface ExploreInteractionListener {
     fun onCancelButtonClicked()
     fun onSearchValueChange(text: String)
     fun onSearchWordDetected(searchKeyWord: List<String>)
-    fun SuggestionList() : List<SuggestItemUiState>
     fun onClickSuggestion(suggestion: SuggestItemUiState)
+    fun onSearchQuery()
     fun clearAllLocalSuggestions()
     fun getMoviesGenres()
     fun getSeriesGenres()

--- a/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreScreen.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreScreen.kt
@@ -1,6 +1,5 @@
 package com.moscow.cineverse.screen.explore
 
-import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -30,7 +29,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -38,10 +36,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 import com.moscow.cineverse.designSystem.component.PillLabel
 import com.moscow.cineverse.designSystem.component.ViewMode
 import com.moscow.cineverse.designSystem.component.ViewModeToggle
@@ -49,6 +45,7 @@ import com.moscow.cineverse.designSystem.component.search.SearchBar
 import com.moscow.cineverse.designSystem.component.tabs.ExploreTabs
 import com.moscow.cineverse.designSystem.component.tabs.ExploreTabsPages
 import com.moscow.cineverse.designSystem.theme.Theme
+import com.moscow.cineverse.navigation.LocalNavController
 import com.moscow.cineverse.navigation.routes.CastDetailsRoute
 import com.moscow.cineverse.screen.component.movie_poster_card.MediaItemUi
 import com.moscow.cineverse.screen.component.movie_poster_card.MoviePosterCard
@@ -60,8 +57,8 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun ExploreScreen(
-    navController: NavHostController = rememberNavController(),
     modifier: Modifier = Modifier,
+    navController: NavHostController = LocalNavController.current,
     viewModel: ExploreViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -113,10 +110,14 @@ private fun ExploreScreenContent(
                         .padding(top = 56.dp)
                         .padding(horizontal = 16.dp),
                     value = uiState.searchKeyWord,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                     keyboardActions = KeyboardActions(
                         onNext = {
                             interactionListener.onKeyboardClick()
+                        },
+                        onSearch = {
+                            interactionListener.onSearchQuery()
+
                         }
                     ),
                     onValueChange = { interactionListener.onSearchValueChange(it) },
@@ -207,10 +208,6 @@ private fun ExploreScreenContent(
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 items(uiState.contentList) { item ->
-                                    Log.e(
-                                        "jxjxjxxkx",
-                                        "ExploreScreenContent: ${uiState.contentList}"
-                                    )
                                     when (item) {
                                         is MediaItemUi -> {
                                             MoviePosterCard(
@@ -268,7 +265,7 @@ private fun ExploreScreenContent(
             ) {
                 SearchSuggestion(
                     modifier = Modifier.padding(top = 24.dp),
-                    suggestionList = interactionListener.SuggestionList(),
+                    suggestionList = uiState.displayedSuggestions,
                     isHistory = uiState.showHistory,
                     onClickSuggestion = interactionListener::onClickSuggestion,
                     onClearAllClicked = interactionListener::clearAllLocalSuggestions

--- a/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreScreenState.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreScreenState.kt
@@ -8,16 +8,16 @@ data class ExploreScreenState(
 
     val searchKeyWord: String = "",
 
-    val searchResult: Map<String, List<Any>> = mutableMapOf(),
+    val searchResult: Map<String, List<Any>> = mutableMapOf(
 
-//    val actorsSearchResult: List<ActorUi> = emptyList(),
+    ),
 
-    val remoteSuggestions:List<String> = emptyList(),
-
-    val isSearchBarClickedOn : Boolean = false,
-    val showHistory : Boolean = false,
-    val showSuggestions : Boolean = false,
+    val remoteSuggestions: List<String> = emptyList(),
     val localSuggestions: List<SuggestItemUiState> = listOf(),
+    val displayedSuggestions: List<SuggestItemUiState> = emptyList(),
+    val isSearchBarClickedOn: Boolean = false,
+    val showHistory: Boolean = false,
+    val showSuggestions: Boolean = false,
 
     val genres: List<GenreUi> = emptyList(),
 
@@ -53,6 +53,7 @@ data class ExploreScreenState(
         val profilePath: String,
         val id: Int
     )
+
     data class GenreUi(
         val id: Int,
         val name: String

--- a/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreViewModel.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreViewModel.kt
@@ -1,5 +1,6 @@
 package com.moscow.cineverse.screen.explore
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.android.domain.model.Actor
 import com.android.domain.model.Genre
@@ -193,6 +194,7 @@ class ExploreViewModel(
 
     private fun onGetHistoryDataSuccess(suggestions: List<String>) {
         val suggestions = suggestions.map { SuggestItemUiState(it, isHistory = true) }
+        Log.d("TAG", "onGetHistoryDataSuccess: $suggestions")
         updateState { it.copy(localSuggestions = suggestions, showHistory = true) }
     }
 
@@ -242,27 +244,25 @@ class ExploreViewModel(
         }
     }
 
-     private fun updateDisplayedSuggestions() {
+    private fun updateDisplayedSuggestions() {
         updateState { state ->
-            state.copy(
-                displayedSuggestions = uiState.value.localSuggestions.filter {
-                    it.title.contains(
-                        uiState.value.searchKeyWord,
-                        ignoreCase = true
-                    )
-                } + uiState.value.remoteSuggestions
-//            .filter { remoteSuggestions -> remoteSuggestions !in uiState.value.localSuggestions.map { it.title } }
-                    .map { SuggestItemUiState(it, isHistory = false) }
+            val filteredLocalSuggestions = state.localSuggestions
+                .filter { it.title.contains(state.searchKeyWord, ignoreCase = true) }
 
+            val mappedRemoteSuggestions = state.remoteSuggestions
+                .map { SuggestItemUiState(it, isHistory = false) }
+
+            state.copy(
+                displayedSuggestions = filteredLocalSuggestions + mappedRemoteSuggestions
             )
         }
-
     }
 
     override fun onClickSuggestion(suggestion: SuggestItemUiState) {
         updateState {
             it.copy(
                 searchKeyWord = suggestion.title,
+                displayedSuggestions = emptyList(),
             )
         }
         viewModelScope.launch {
@@ -279,22 +279,20 @@ class ExploreViewModel(
             it.copy(
                 showHistory = false,
                 showSuggestions = false,
-                remoteSuggestions = emptyList()
             )
         }
     }
 
     override fun onSearchQuery() {
+        updateState {
+            it.copy(
+                showHistory = false,
+                showSuggestions = false,
+                displayedSuggestions = emptyList(),
+            )
+        }
         launchAndForget(
             action = {
-                updateState {
-                    it.copy(
-                        showHistory = false,
-                        showSuggestions = false,
-                        remoteSuggestions = emptyList()
-                    )
-                }
-
                 uiState.value.localSuggestions.any { it.title == uiState.value.searchKeyWord }
                     .let { isQueryInHistory ->
                         if (!isQueryInHistory)

--- a/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreViewModel.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreViewModel.kt
@@ -1,11 +1,12 @@
 package com.moscow.cineverse.screen.explore
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.android.domain.model.Actor
 import com.android.domain.model.Genre
 import com.android.domain.model.Movie
 import com.android.domain.model.Series
+import com.android.domain.usecase.CacheSearchQueryUseCase
+import com.android.domain.usecase.ClearSearchHistoryUseCase
 import com.android.domain.usecase.GenreUseCase
 import com.android.domain.usecase.GetLocalSuggestions
 import com.android.domain.usecase.GetMovieByGenreIdUseCase
@@ -34,6 +35,8 @@ class ExploreViewModel(
     val genreUseCase: GenreUseCase,
     private val getMovieByGenreIdUseCase: GetMovieByGenreIdUseCase,
     private val getSeriesByGenreIdUseCase: GetSeriesByGenreIdUseCase,
+    private val cacheSearchQueryUseCase: CacheSearchQueryUseCase,
+    private val clearSearchHistoryUseCase: ClearSearchHistoryUseCase,
 ) : BaseViewModel<ExploreScreenState, ExploreScreenEvents>(ExploreScreenState()),
     ExploreInteractionListener {
 
@@ -114,7 +117,6 @@ class ExploreViewModel(
 
     private fun onActorSearchSuccess(actors: List<Actor>) {
         updateState { state ->
-            Log.e("jxjxjxxkx", "onActorSearchSuccess: $actors")
             state.copy(
                 searchResult = state.searchResult.plus(ExploreTabsPages.ACTORS.toTitle() to actors.map { it.toUi() }),
                 isLoading = false
@@ -124,12 +126,15 @@ class ExploreViewModel(
     }
 
     private fun onMovieSearchFailed(e: Throwable) {
+        updateState { it.copy(isLoading = false, error = e.message) }
     }
 
     private fun onSeriesSearchFailed(e: Throwable) {
+        updateState { it.copy(isLoading = false, error = e.message) }
     }
 
     private fun onActorsSearchFailed(e: Throwable) {
+        updateState { it.copy(isLoading = false, error = e.message) }
     }
 
     private fun onLoading() {
@@ -220,8 +225,11 @@ class ExploreViewModel(
             it.copy(
                 searchKeyWord = text,
                 showSuggestions = true,
+                showHistory = text.isBlank(),
+                remoteSuggestions = emptyList()
             )
         }
+        updateDisplayedSuggestions()
     }
 
     override fun onSearchWordDetected(searchKeyWord: List<String>) {
@@ -233,14 +241,21 @@ class ExploreViewModel(
         }
     }
 
-    override fun SuggestionList(): List<SuggestItemUiState> {
-        return (uiState.value.localSuggestions.filter {
-            it.title.contains(
-                uiState.value.searchKeyWord,
-                ignoreCase = true
+     private fun updateDisplayedSuggestions() {
+        updateState { state ->
+            state.copy(
+                displayedSuggestions = uiState.value.localSuggestions.filter {
+                    it.title.contains(
+                        uiState.value.searchKeyWord,
+                        ignoreCase = true
+                    )
+                } + uiState.value.remoteSuggestions
+//            .filter { remoteSuggestions -> remoteSuggestions !in uiState.value.localSuggestions.map { it.title } }
+                    .map { SuggestItemUiState(it, isHistory = false) }
+
             )
-        } + uiState.value.remoteSuggestions.filter { remoteSuggestions -> remoteSuggestions !in uiState.value.localSuggestions.map { it.title } }
-            .map { SuggestItemUiState(it, isHistory = false) })
+        }
+
     }
 
     override fun onClickSuggestion(suggestion: SuggestItemUiState) {
@@ -249,14 +264,15 @@ class ExploreViewModel(
                 searchKeyWord = suggestion.title,
             )
         }
-        if (suggestion.isHistory) {
-            searchMovie(isHistory = true)
-            searchSeries(isHistory = true)
-            searchActor(isHistory = true)
-        } else {
-            searchMovie()
-            searchSeries()
-            searchActor()
+        viewModelScope.launch {
+            suggestion.isHistory.let {
+                if (!it) {
+                    cacheSearchQueryUseCase.cacheSearchQuery(suggestion.title)
+                }
+                searchMovie(it)
+                searchSeries(it)
+                searchActor(it)
+            }
         }
         updateState {
             it.copy(
@@ -267,8 +283,43 @@ class ExploreViewModel(
         }
     }
 
+    override fun onSearchQuery() {
+        launchAndForget(
+            action = {
+                updateState {
+                    it.copy(
+                        showHistory = false,
+                        showSuggestions = false,
+                        remoteSuggestions = emptyList()
+                    )
+                }
+
+                uiState.value.localSuggestions.any { it.title == uiState.value.searchKeyWord }
+                    .let { isQueryInHistory ->
+                        if (!isQueryInHistory)
+                            cacheSearchQueryUseCase.cacheSearchQuery(uiState.value.searchKeyWord)
+                        searchMovie(isQueryInHistory)
+                        searchSeries(isQueryInHistory)
+                        searchActor(isQueryInHistory)
+                    }
+            },
+            onError = ::onSearchQueryError
+        )
+    }
+
+    private fun onSearchQueryError(e: Throwable) {
+        updateState { it.copy(error = e.message) }
+    }
+
     override fun clearAllLocalSuggestions() {
-        Log.d("dddddddddddddddd", "Clear allllllllllllllllll")
+        launchAndForget(
+            action = clearSearchHistoryUseCase::clearSearchHistory,
+            onError = ::onClearSearchHistoryError
+        )
+    }
+
+    private fun onClearSearchHistoryError(e: Throwable) {
+        updateState { it.copy(showHistory = false, error = e.message) }
     }
 
     override fun getMoviesGenres() {
@@ -484,7 +535,7 @@ class ExploreViewModel(
             }
             updateState {
                 it.copy(
-                    shouldShowGenres = true,
+                    shouldShowGenres = it.selectedTab != ExploreTabsPages.ACTORS,
                     contentList = if (it.selectedTab == ExploreTabsPages.MOVIES)
                         it.movies
                     else

--- a/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreViewModel.kt
+++ b/presentation/src/main/java/com/moscow/cineverse/screen/explore/ExploreViewModel.kt
@@ -173,6 +173,7 @@ class ExploreViewModel(
         viewModelScope.launch {
             updateState { it.copy(remoteSuggestions = suggestion) }
         }
+        updateDisplayedSuggestions()
     }
 
     override fun onSearchBarClickedOn() {


### PR DESCRIPTION
#148 
- Implemented caching and automatic clearing of search queries in the Explore 
- Resolved issue where empty data responses were not handled 
- Refactored interaction to function as a method with a return type for proper state updates