### PR TITLE
Refactor: Remove test_coverage dependency from Firebase distribution …

### DIFF
--- a/.github/workflows/cd_deploy_to_firebase_distribution.yml
+++ b/.github/workflows/cd_deploy_to_firebase_distribution.yml
@@ -36,7 +36,7 @@ jobs:
   deploy:
     name: 📱 Distribute Debug APK to Firebase App Distribution
     runs-on: ubuntu-latest
-    needs: [build, test_coverage]
+    needs: [build]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
…workflow

The `deploy` job in the `cd_deploy_to_firebase_distribution.yml` workflow no longer depends on the `test_coverage` job. It now only depends on the `build` job.