### PR TITLE
Refactor: Remove test_coverage dependency from Firebase distribution …

### DIFF
--- a/.github/workflows/cd_deploy_to_firebase_distribution.yml
+++ b/.github/workflows/cd_deploy_to_firebase_distribution.yml
@@ -26,7 +26,9 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v3
-
+      - name: Generate keys.properties
+        run: |
+          echo "BEARER_TOKEN=${{ secrets.BEARER_TOKEN }}" > keys.properties
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 


### PR DESCRIPTION
…workflow

The `deploy` job in the `cd_deploy_to_firebase_distribution.yml` workflow no longer depends on the `test_coverage` job. It now only depends on the `build` job.