### PR TITLE
Fix: Update branch name in CI workflows and clear `mobilesdk_app_id`

### DIFF
--- a/.github/workflows/cd_deploy_to_firebase_distribution.yml
+++ b/.github/workflows/cd_deploy_to_firebase_distribution.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Generate keys.properties
         run: |
           echo "BEARER_TOKEN=${{ secrets.BEARER_TOKEN }}" > keys.properties
+          
+
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 

--- a/.github/workflows/ci_test_coverage_check.yaml
+++ b/.github/workflows/ci_test_coverage_check.yaml
@@ -19,37 +19,10 @@ jobs:
           distribution: temurin
           cache: gradle
 
-      - name: Create mock google-services.json
+      - name: Create google-services.json
         run: |
-          echo '{
-            "project_info": {
-              "project_number": "123456789",
-              "firebase_url": "https://mock-project.firebaseio.com",
-              "project_id": "mock-project-id",
-              "storage_bucket": "mock-project.appspot.com"
-            },
-            "client": [
-              {
-                "client_info": {
-                  "mobilesdk_app_id": "",
-                  "android_client_info": {
-                    "package_name": "com.moscow.cineverse"
-                  }
-                },
-                "oauth_client": [],
-                "api_key": [
-                          {
-                            "current_key": ""
-                          }
-                      ], 
-                "services": {
-                  "appinvite_service": {
-                    "other_platform_oauth_client": []
-                  }
-                }
-              }
-            ]
-          }' > app/google-services.json
+#          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/src/debug/google-services.json
+           echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/google-services.json
       - name: Generate keys.properties
         run: |
           echo "BEARER_TOKEN=${{ secrets.BEARER_TOKEN }}" > keys.properties

--- a/.github/workflows/ci_test_coverage_check.yaml
+++ b/.github/workflows/ci_test_coverage_check.yaml
@@ -31,7 +31,7 @@ jobs:
             "client": [
               {
                 "client_info": {
-                  "mobilesdk_app_id": "1:123456789:android:abcdefgh",
+                  "mobilesdk_app_id": "",
                   "android_client_info": {
                     "package_name": "com.moscow.cineverse"
                   }

--- a/.github/workflows/ci_test_coverage_check.yaml
+++ b/.github/workflows/ci_test_coverage_check.yaml
@@ -21,7 +21,6 @@ jobs:
 
       - name: Create google-services.json
         run: |
-#          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/src/debug/google-services.json
            echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/google-services.json
       - name: Generate keys.properties
         run: |

--- a/.github/workflows/ci_verify_build.yml
+++ b/.github/workflows/ci_verify_build.yml
@@ -2,7 +2,7 @@ name: CI - Verify build
 
 on:
   pull_request:
-    branches: [main, development]
+    branches: [ develop ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_verify_build.yml
+++ b/.github/workflows/ci_verify_build.yml
@@ -46,25 +46,12 @@ jobs:
       - name: Create keys.properties
         run: |
             echo "TMDB_API_KEY=\"${{ secrets.TMDB_API_KEY }}\"" > data/keys.properties
-
-#      - name: Create debug directory
-#        run: mkdir -p app/src/debug
-
       - name: Create google-services.json
         run: |
-#          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/src/debug/google-services.json
           echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/google-services.json
-
-#      - name: Verify google-services.json
-#        run: |
-#          ls -l app/src/debug/
-#          cat app/src/debug/google-services.json
 
       - name: Setup Gradlew
         run: chmod +x ./gradlew
 
       - name: Build (assembleDebug)
         run: ./gradlew assembleDebug --stacktrace --info
-
-#      - name: Build without tests
-#        run: ./gradlew assemble -x lintVitalRelease -x lint

--- a/.github/workflows/ci_verify_build.yml
+++ b/.github/workflows/ci_verify_build.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Create keys.properties
         run: |
             echo "TMDB_API_KEY=\"${{ secrets.TMDB_API_KEY }}\"" > data/keys.properties
+
+      - name: Create google-services.json
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/src/debug/google-services.json
+      
+
       - name: Setup Gradlew
         run: chmod +x ./gradlew
 

--- a/.github/workflows/ci_verify_build.yml
+++ b/.github/workflows/ci_verify_build.yml
@@ -47,18 +47,18 @@ jobs:
         run: |
             echo "TMDB_API_KEY=\"${{ secrets.TMDB_API_KEY }}\"" > data/keys.properties
 
-      - name: Create debug directory
-        run: mkdir -p app/src/debug
+#      - name: Create debug directory
+#        run: mkdir -p app/src/debug
 
       - name: Create google-services.json
         run: |
-          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/src/debug/google-services.json
+#          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/src/debug/google-services.json
           echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/google-services.json
 
-      - name: Verify google-services.json
-        run: |
-          ls -l app/src/debug/
-          cat app/src/debug/google-services.json
+#      - name: Verify google-services.json
+#        run: |
+#          ls -l app/src/debug/
+#          cat app/src/debug/google-services.json
 
       - name: Setup Gradlew
         run: chmod +x ./gradlew
@@ -66,5 +66,5 @@ jobs:
       - name: Build (assembleDebug)
         run: ./gradlew assembleDebug --stacktrace --info
 
-      - name: Build without tests
-        run: ./gradlew assemble -x lintVitalRelease -x lint
+#      - name: Build without tests
+#        run: ./gradlew assemble -x lintVitalRelease -x lint

--- a/.github/workflows/ci_verify_build.yml
+++ b/.github/workflows/ci_verify_build.yml
@@ -47,16 +47,24 @@ jobs:
         run: |
             echo "TMDB_API_KEY=\"${{ secrets.TMDB_API_KEY }}\"" > data/keys.properties
 
+      - name: Create debug directory
+        run: mkdir -p app/src/debug
+
       - name: Create google-services.json
         run: |
           echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/src/debug/google-services.json
-      
+          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > app/google-services.json
+
+      - name: Verify google-services.json
+        run: |
+          ls -l app/src/debug/
+          cat app/src/debug/google-services.json
 
       - name: Setup Gradlew
         run: chmod +x ./gradlew
 
       - name: Build (assembleDebug)
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleDebug --stacktrace --info
 
       - name: Build without tests
         run: ./gradlew assemble -x lintVitalRelease -x lint

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,14 @@ android {
     }
 
     buildTypes {
+//        release {
+//            isMinifyEnabled = false
+//            isShrinkResources = true
+//            proguardFiles(
+//                getDefaultProguardFile("proguard-android-optimize.txt"),
+//                "proguard-rules.pro"
+//            )
+//        }
         debug {
             isDebuggable = true
             isMinifyEnabled = false


### PR DESCRIPTION
This commit includes two changes to the GitHub Actions workflows:

1.  **Branch Name Update (`.github/workflows/ci_verify_build.yml`):** The `pull_request` trigger in the `ci_verify_build.yml` workflow has been updated to target the `develop` branch instead of `main` and `development`.

2.  **Clear `mobilesdk_app_id` (`.github/workflows/ci_test_coverage_check.yaml`):** The `mobilesdk_app_id` field in the mock `google-services.json` within the `ci_test_coverage_check.yaml` workflow has been set to an empty string.